### PR TITLE
Add PingPath deeplink on pro page

### DIFF
--- a/src/partials/HeroPro.tsx
+++ b/src/partials/HeroPro.tsx
@@ -71,6 +71,15 @@ function HeroPro(props) {
                     Download Now
                   </a>
                 </div>
+                <div className="sm:ml-4">
+                  <a
+                    className="btn text-white bg-gray-600 hover:bg-gray-700 w-full mb-4 sm:w-auto sm:mb-0"
+                    href="pingpath://"
+                    aria-label="Return to the PingPath app"
+                  >
+                    Back to PingPath
+                  </a>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a button linking to `pingpath://` so users can return to the app
- ensure newline at end of `HeroPro.tsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d0e838088331933cc047245a17b4