### PR TITLE
Add Get Help button

### DIFF
--- a/src/partials/HeroPro.tsx
+++ b/src/partials/HeroPro.tsx
@@ -81,6 +81,15 @@ function HeroPro(props) {
                   </a>
                 </div>
               </div>
+              <div className="text-center mt-4">
+                <a
+                  className="btn text-white bg-blue-600 hover:bg-blue-700 w-full sm:w-auto"
+                  href="mailto:andreasink17@gmail.com"
+                  aria-label="Get help for PingPath"
+                >
+                  Get Help
+                </a>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- add a new Get Help button under Back to PingPath on the PingPath Pro screen

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d50d8b20833192fcaa2620aa3bb2